### PR TITLE
dynamic block replaced

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -100,16 +100,9 @@ resource "azurerm_mssql_database" "mssql_database" {
     }
   }
 
-  dynamic "short_term_retention_policy" {
-    for_each = compact([
-      local.mssql_database[each.key].short_term_retention_policy.retention_days,
-      local.mssql_database[each.key].short_term_retention_policy.backup_interval_in_hours
-    ])
-
-    content {
-      retention_days           = local.mssql_database[each.key].short_term_retention_policy.retention_days
-      backup_interval_in_hours = local.mssql_database[each.key].short_term_retention_policy.backup_interval_in_hours
-    }
+  short_term_retention_policy {
+    retention_days           = local.mssql_database[each.key].short_term_retention_policy.retention_days
+    backup_interval_in_hours = local.mssql_database[each.key].short_term_retention_policy.backup_interval_in_hours
   }
 
   tags = local.mssql_server[each.key].tags


### PR DESCRIPTION
This change fixes the following issue with dynamic block usage when defining short_term_retention_policy:

│ Error: Too many short_term_retention_policy blocks
│
│   on .terraform/modules/mssql/main.tf line 109, in resource "azurerm_mssql_database" "mssql_database":
│  109:     content {
│
│ No more than 1 "short_term_retention_policy" blocks are allowed